### PR TITLE
Add vitest utilities tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
@@ -18,7 +19,9 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.9",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^15.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { fmt, clamp } from '../utils/format.js';
+import { cpsFrom } from '../components/CookieCraze.jsx';
+
+describe('fmt', () => {
+  it('formats large numbers with suffix', () => {
+    expect(fmt(1500)).toBe('1.5K');
+  });
+
+  it('returns infinity symbol for non-finite numbers', () => {
+    expect(fmt(Infinity)).toBe('∞');
+  });
+});
+
+describe('clamp', () => {
+  it('clamps values within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+});
+
+describe('cpsFrom', () => {
+  it('computes cookies per second without upgrades', () => {
+    const items = { cursor: 1 };
+    const upgrades = {};
+    const cps = cpsFrom(items, upgrades, 0);
+    expect(cps).toBeCloseTo(0.22);
+  });
+});

--- a/src/components/CookieCraze.jsx
+++ b/src/components/CookieCraze.jsx
@@ -110,7 +110,7 @@ export default function CookieCraze() {
     mult.farm *= 1 + 0.002 * fac; // +0,2%/usine
     return mult;
   };
-  const cpsFrom = (items, upgrades, chips, stakeMulti = 1) => {
+  export const cpsFrom = (items, upgrades, chips, stakeMulti = 1) => {
     const mult = computePerItemMult(items, upgrades);
     let cps = 0; for (const it of ITEMS) cps += (items[it.id] || 0) * it.cps * (mult[it.id] || 1);
     return cps * (1 + (chips || 0) * 0.02) * stakeMulti;


### PR DESCRIPTION
## Summary
- add vitest and testing-library packages and test script
- export `cpsFrom` and add unit tests for `fmt`, `clamp`, and `cpsFrom`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70cd895d48331a730e24f4a9f783d